### PR TITLE
Fixes crash caused by invalid memory access

### DIFF
--- a/5G-SIM-V2IN/lteNR/src/stack/mac/scheduling_modules/LtePf.cc
+++ b/5G-SIM-V2IN/lteNR/src/stack/mac/scheduling_modules/LtePf.cc
@@ -222,12 +222,15 @@ void LtePf::prepareSchedule() //
 			if (!active) {
 				//EV << NOW << "LtePf::execSchedule NOT ACTIVE" << endl;
 				activeConnectionTempSet_.erase(current.x_);
-				//std::set<std::pair<unsigned int, unsigned int>> temp;
-				for (auto var : qfiNodeCidSizeMap) {
-					if (var.second.first == current.x_) {
-						//temp.insert(var.first);
-						qfiNodeCidSizeMap.erase(var.first);
-					}
+				
+				auto itr = qfiNodeCidSizeMap.begin();
+				while (itr != qfiNodeCidSizeMap.end()) {
+				    if (itr->second.first == current.x_) {
+				       itr = qfiNodeCidSizeMap.erase(itr);
+				    }
+				    else {
+				       ++itr;
+				    }
 				}
 
 			}


### PR DESCRIPTION
Modifying std::map (erase) on references may lead to invalid mem access. Changed to use iterators instead, which guarantee modification access.