### PR TITLE
Enable UPF to be part of compound module, PPP-encapsulated connection via N9 interface

### DIFF
--- a/5G-SIM-V2IN/lteNR/src/nr/corenetwork/nodes/UPF.ned
+++ b/5G-SIM-V2IN/lteNR/src/nr/corenetwork/nodes/UPF.ned
@@ -44,12 +44,19 @@ module UPF extends NodeBase
 
     submodules:
         trafficFlowFilter: TrafficFlowFilterNR {
-            ownerType = nodeType;
-            @display("p=813,206");
+            parameters:
+                ownerType = nodeType;
+                @display("p=813,206");
+            gates:
+                fromToN9Interface[sizeof(n9Interface)];
         }
         pppInterface: PPPInterface {
             @display("p=727,386");
         }
+        pppN9Interface[sizeof(n9Interface)]: PPPInterface {
+            @display("is=s");
+        }
+
         udp: UDP {
             @display("p=329,206");
         }
@@ -73,7 +80,8 @@ module UPF extends NodeBase
         trafficFlowFilter.gtpUserGateOut --> gtp_user.trafficFlowFilterGate;
 
         for i=0..sizeof(n9Interface)-1 {
-            n9Interface[i] <--> { @display("m=s"); } <--> trafficFlowFilter.fromToN9Interface++;
+            n9Interface[i] <--> { @display("m=s"); } <--> pppN9Interface[i].phys;
+            pppN9Interface[i].upperLayerOut --> trafficFlowFilter.fromToN9Interface$i[i];
+            pppN9Interface[i].upperLayerIn <-- trafficFlowFilter.fromToN9Interface$o[i];
         }
-
 }

--- a/5G-SIM-V2IN/lteNR/src/nr/corenetwork/nodes/UPF.ned
+++ b/5G-SIM-V2IN/lteNR/src/nr/corenetwork/nodes/UPF.ned
@@ -40,7 +40,7 @@ module UPF extends NodeBase
         @display("bgb=920,462;i=device/mainframe");
     gates:
         inout filterGate @labels(PPPFrame-conn);
-        inout n9Interface[] @loose;
+        inout n9Interface[] @loose @labels(PPPFrame-conn);
 
     submodules:
         trafficFlowFilter: TrafficFlowFilterNR {

--- a/5G-SIM-V2IN/lteNR/src/nr/epc/gtp/GtpUserNR.cc
+++ b/5G-SIM-V2IN/lteNR/src/nr/epc/gtp/GtpUserNR.cc
@@ -29,11 +29,19 @@ void GtpUserNR::initialize(int stage) {
 
     ownerType_ = selectOwnerType(getAncestorPar("nodeType"));
 
+    cModule* upfModule = nullptr;
     if(ownerType_ == ENB || ownerType_ == GNB){
-    	getParentModule()->gate("ppp$o")->getNextGate()->getOwnerModule()->getName();
-    	upfAddress_ = L3AddressResolver().resolve(getParentModule()->gate("ppp$o")->getNextGate()->getOwnerModule()->getName());
+    	upfModule = getParentModule()->gate("ppp$o")->getNextGate()->getOwnerModule();
+    	if (!(upfModule->hasPar("nodeType") && strcmp(upfModule->par("nodeType"), "UPF") == 0)) {
+    	    // if: connected gate is part of container module, UPF is a sub-component
+    	    upfModule = upfModule->getModuleByPath(".upf");
+    	}
+    	// else: connected gate is part of UPF module
     }else if(ownerType_ == USER_PLANE_FUNCTION){
-    	upfAddress_ = L3AddressResolver().resolve(getParentModule()->getName());
+        upfModule = getParentModule();
+    }
+    if (upfModule) {
+        upfAddress_ = L3AddressResolver().resolve(upfModule->getFullPath().c_str());
     }
 }
 


### PR DESCRIPTION
The changes enable the UPF module to be part of a compound module (e.g., inside an umbrella MEC node). Therefore, it is necessary that UPF-UPF exchange via their N9 interfaces is PPP-encapsulated instead of direct communication via OMNET++ gates.
Changes should be compatible with older versions.