### PR TITLE
avoid deletion of uninitalized object when device is of non-UE type

### DIFF
--- a/5G-SIM-V2IN/lteNR/src/nr/stack/rlc/um/NRRlcUm.h
+++ b/5G-SIM-V2IN/lteNR/src/nr/stack/rlc/um/NRRlcUm.h
@@ -54,7 +54,7 @@ protected:
     cOutVector UERlcThroughputPerSecondUl;
     cOutVector UERlcThroughputPerSecondDl;
 
-    cMessage * throughputTimer;
+    cMessage * throughputTimer = nullptr;
     double throughputInterval;
     std::string nodeType;
 


### PR DESCRIPTION
Fixes invalid memory access during simulation network cleanup:
```
<!> cancelEvent(): Message (omnetpp::cObject) is not a self-message -- during network cleanup
```

